### PR TITLE
Release/2.3.0

### DIFF
--- a/changelogs/jrs-client-2.3.0.changelog.txt
+++ b/changelogs/jrs-client-2.3.0.changelog.txt
@@ -3,4 +3,6 @@
 * Created Metis Server Entity to subscribe and notify them for accepted blocks and unconfirmed transactions via websocket
 * Changed default behaviour in getBlocks and GetAccountBlocks request, transactions info is not included by default.
 * Read Message by transactionId changed, if transactionId is not found, look for in the unconfirmed transactions
-
+* Defined new messaging subtypes for metis
+* Defined a new type and subtypes for jupiter-fs transactions
+* Defined a new ENCRYPTED_DATA_MESSAGE_FEE for jupiter-fs transactions

--- a/src/java/nxt/Appendix.java
+++ b/src/java/nxt/Appendix.java
@@ -478,6 +478,13 @@ public interface Appendix {
                 return ((AbstractEncryptedMessage)appendage).getEncryptedDataLength() - 16;
             }
         };
+        
+        private static final Fee ENCRYPTED_DATA_MESSAGE_FEE = new Fee.SizeBasedFee(Fee.MIN_CONSTANT_DATA_FEE, Fee.MIN_DATA_FEE, 32) {
+            @Override
+            public int getSize(TransactionImpl transaction, Appendix appendage) {
+                return ((AbstractEncryptedMessage)appendage).getEncryptedDataLength() - 16;
+            }
+        };
 
         private EncryptedData encryptedData;
         private final boolean isText;
@@ -533,7 +540,12 @@ public interface Appendix {
 
         @Override
         public Fee getBaselineFee(Transaction transaction) {
-            return ENCRYPTED_MESSAGE_FEE;
+        	if (Byte.compare(TransactionType.TYPE_DATA_FS, transaction.getType().getType()) == 0 &&
+        		Byte.compare(TransactionType.SUBTYPE_DATA_FS_BINARY, transaction.getType().getSubtype()) == 0) {
+        		return ENCRYPTED_DATA_MESSAGE_FEE;
+        	} else {
+        		return ENCRYPTED_MESSAGE_FEE;
+        	}
         }
 
         @Override

--- a/src/java/nxt/Attachment.java
+++ b/src/java/nxt/Attachment.java
@@ -140,7 +140,38 @@ public interface Attachment extends Appendix {
         public TransactionType getTransactionType() {
             return TransactionType.Messaging.ARBITRARY_MESSAGE;
         }
+    };
+    
+    EmptyAttachment METIS_ACCOUNT_INFO = new EmptyAttachment() {
 
+        @Override
+        public TransactionType getTransactionType() {
+            return TransactionType.Messaging.METIS_ACCOUNT_INFO;
+        }
+    };
+    
+    EmptyAttachment METIS_DATA = new EmptyAttachment() {
+
+        @Override
+        public TransactionType getTransactionType() {
+            return TransactionType.Messaging.METIS_DATA;
+        }
+    };
+    
+    EmptyAttachment METIS_CHANNEL_MEMBER = new EmptyAttachment() {
+
+        @Override
+        public TransactionType getTransactionType() {
+            return TransactionType.Messaging.METIS_CHANNEL_MEMBER;
+        }
+    };
+    
+    EmptyAttachment METIS_CHANNEL_INVITATION = new EmptyAttachment() {
+
+        @Override
+        public TransactionType getTransactionType() {
+            return TransactionType.Messaging.METIS_CHANNEL_INVITATION;
+        }
     };
 
     final class MessagingAliasAssignment extends AbstractAttachment {

--- a/src/java/nxt/Attachment.java
+++ b/src/java/nxt/Attachment.java
@@ -154,7 +154,15 @@ public interface Attachment extends Appendix {
 
         @Override
         public TransactionType getTransactionType() {
-            return TransactionType.Messaging.METIS_DATA;
+            return TransactionType.DataFS.METIS_DATA;
+        }
+    };
+    
+    EmptyAttachment METIS_METADATA = new EmptyAttachment() {
+
+        @Override
+        public TransactionType getTransactionType() {
+            return TransactionType.DataFS.METIS_METADATA;
         }
     };
     

--- a/src/java/nxt/Fee.java
+++ b/src/java/nxt/Fee.java
@@ -18,11 +18,15 @@
 
 package nxt;
 
+import nxt.util.Logger;
+
 public interface Fee {
 
     long getFee(TransactionImpl transaction, Appendix appendage);
 
     long MIN_FEE = 10L;
+    long MIN_DATA_FEE = 100L;
+    long MIN_CONSTANT_DATA_FEE = 500L;
     long MIN_PRUNABLE_FEE = 1L;
 
     Fee DEFAULT_FEE = new Fee.ConstantFee(MIN_FEE);
@@ -71,7 +75,8 @@ public interface Fee {
             if (size < 0) {
                 return constantFee;
             }
-            return Math.addExact(constantFee, Math.multiplyExact((long) (size / unitSize), feePerSize));
+            long totalFee = Math.addExact(constantFee, Math.multiplyExact((long) (size / unitSize), feePerSize));
+            return totalFee;
         }
 
         public abstract int getSize(TransactionImpl transaction, Appendix appendage);

--- a/src/java/nxt/TransactionType.java
+++ b/src/java/nxt/TransactionType.java
@@ -62,6 +62,11 @@ public abstract class TransactionType {
     private static final byte SUBTYPE_MESSAGING_PHASING_VOTE_CASTING = 9;
     private static final byte SUBTYPE_MESSAGING_ACCOUNT_PROPERTY = 10;
     private static final byte SUBTYPE_MESSAGING_ACCOUNT_PROPERTY_DELETE = 11;
+    
+    public static final byte SUBTYPE_MESSAGING_METIS_ACCOUNT_INFO = 12;
+    public static final byte SUBTYPE_MESSAGING_METIS_CHANNEL_INVITATION = 13;
+    public static final byte SUBTYPE_MESSAGING_METIS_CHANNEL_MEMBER = 14;
+    public static final byte SUBTYPE_MESSAGING_METIS_DATA = 15;
 
     private static final byte SUBTYPE_COLORED_COINS_ASSET_ISSUANCE = 0;
     private static final byte SUBTYPE_COLORED_COINS_ASSET_TRANSFER = 1;
@@ -122,6 +127,14 @@ public abstract class TransactionType {
                         return Messaging.ACCOUNT_PROPERTY;
                     case SUBTYPE_MESSAGING_ACCOUNT_PROPERTY_DELETE:
                         return Messaging.ACCOUNT_PROPERTY_DELETE;
+                    case SUBTYPE_MESSAGING_METIS_ACCOUNT_INFO:
+                        return Messaging.METIS_ACCOUNT_INFO;
+                    case SUBTYPE_MESSAGING_METIS_CHANNEL_INVITATION:
+                        return Messaging.METIS_CHANNEL_INVITATION;
+                    case SUBTYPE_MESSAGING_METIS_CHANNEL_MEMBER:
+                        return Messaging.METIS_CHANNEL_MEMBER;
+                    case SUBTYPE_MESSAGING_METIS_DATA:
+                        return Messaging.METIS_DATA;
                     default:
                         return null;
                 }
@@ -436,6 +449,245 @@ public abstract class TransactionType {
         final void undoAttachmentUnconfirmed(Transaction transaction, Account senderAccount) {
         }
 
+        
+        public final static TransactionType METIS_CHANNEL_INVITATION = new Messaging() {
+
+            @Override
+            public final byte getSubtype() {
+                return TransactionType.SUBTYPE_MESSAGING_METIS_CHANNEL_INVITATION;
+            }
+
+            @Override
+            public LedgerEvent getLedgerEvent() {
+                return LedgerEvent.ARBITRARY_MESSAGE;
+            }
+
+            @Override
+            public String getName() {
+                return "MetisChannelInvitation";
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(ByteBuffer buffer) throws NxtException.NotValidException {
+                return Attachment.METIS_CHANNEL_INVITATION;
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(JSONObject attachmentData) throws NxtException.NotValidException {
+                return Attachment.METIS_CHANNEL_INVITATION;
+            }
+
+            @Override
+            void applyAttachment(Transaction transaction, Account senderAccount, Account recipientAccount) {
+            }
+
+            @Override
+            void validateAttachment(Transaction transaction) throws NxtException.ValidationException {
+                Attachment attachment = transaction.getAttachment();
+                if (transaction.getAmountNQT() != 0) {
+                    throw new NxtException.NotValidException("Invalid arbitrary message: " + attachment.getJSONObject());
+                }
+                if (transaction.getRecipientId() == Genesis.CREATOR_ID) {
+                    throw new NxtException.NotValidException("Sending messages to Genesis not allowed.");
+                }
+            }
+
+            @Override
+            public boolean canHaveRecipient() {
+                return true;
+            }
+
+            @Override
+            public boolean mustHaveRecipient() {
+                return false;
+            }
+
+            @Override
+            public boolean isPhasingSafe() {
+                return false;
+            }
+
+        };
+        
+        public final static TransactionType METIS_CHANNEL_MEMBER = new Messaging() {
+
+            @Override
+            public final byte getSubtype() {
+                return TransactionType.SUBTYPE_MESSAGING_METIS_CHANNEL_MEMBER;
+            }
+
+            @Override
+            public LedgerEvent getLedgerEvent() {
+                return LedgerEvent.ARBITRARY_MESSAGE;
+            }
+
+            @Override
+            public String getName() {
+                return "MetisChannelMember";
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(ByteBuffer buffer) throws NxtException.NotValidException {
+                return Attachment.METIS_CHANNEL_MEMBER;
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(JSONObject attachmentData) throws NxtException.NotValidException {
+                return Attachment.METIS_CHANNEL_MEMBER;
+            }
+
+            @Override
+            void applyAttachment(Transaction transaction, Account senderAccount, Account recipientAccount) {
+            }
+
+            @Override
+            void validateAttachment(Transaction transaction) throws NxtException.ValidationException {
+                Attachment attachment = transaction.getAttachment();
+                if (transaction.getAmountNQT() != 0) {
+                    throw new NxtException.NotValidException("Invalid arbitrary message: " + attachment.getJSONObject());
+                }
+                if (transaction.getRecipientId() == Genesis.CREATOR_ID) {
+                    throw new NxtException.NotValidException("Sending messages to Genesis not allowed.");
+                }
+            }
+
+            @Override
+            public boolean canHaveRecipient() {
+                return true;
+            }
+
+            @Override
+            public boolean mustHaveRecipient() {
+                return false;
+            }
+
+            @Override
+            public boolean isPhasingSafe() {
+                return false;
+            }
+
+        };
+
+        
+        public final static TransactionType METIS_DATA = new Messaging() {
+
+            @Override
+            public final byte getSubtype() {
+                return TransactionType.SUBTYPE_MESSAGING_METIS_DATA;
+            }
+
+            @Override
+            public LedgerEvent getLedgerEvent() {
+                return LedgerEvent.ARBITRARY_MESSAGE;
+            }
+
+            @Override
+            public String getName() {
+                return "MetisData";
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(ByteBuffer buffer) throws NxtException.NotValidException {
+                return Attachment.METIS_DATA;
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(JSONObject attachmentData) throws NxtException.NotValidException {
+                return Attachment.METIS_DATA;
+            }
+
+            @Override
+            void applyAttachment(Transaction transaction, Account senderAccount, Account recipientAccount) {
+            }
+
+            @Override
+            void validateAttachment(Transaction transaction) throws NxtException.ValidationException {
+                Attachment attachment = transaction.getAttachment();
+                if (transaction.getAmountNQT() != 0) {
+                    throw new NxtException.NotValidException("Invalid arbitrary message: " + attachment.getJSONObject());
+                }
+                if (transaction.getRecipientId() == Genesis.CREATOR_ID) {
+                    throw new NxtException.NotValidException("Sending messages to Genesis not allowed.");
+                }
+            }
+
+            @Override
+            public boolean canHaveRecipient() {
+                return true;
+            }
+
+            @Override
+            public boolean mustHaveRecipient() {
+                return false;
+            }
+
+            @Override
+            public boolean isPhasingSafe() {
+                return false;
+            }
+
+        };
+
+        
+        public final static TransactionType METIS_ACCOUNT_INFO = new Messaging() {
+
+            @Override
+            public final byte getSubtype() {
+                return TransactionType.SUBTYPE_MESSAGING_METIS_ACCOUNT_INFO;
+            }
+
+            @Override
+            public LedgerEvent getLedgerEvent() {
+                return LedgerEvent.ARBITRARY_MESSAGE;
+            }
+
+            @Override
+            public String getName() {
+                return "MetisAccountInfo";
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(ByteBuffer buffer) throws NxtException.NotValidException {
+                return Attachment.METIS_ACCOUNT_INFO;
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(JSONObject attachmentData) throws NxtException.NotValidException {
+                return Attachment.METIS_ACCOUNT_INFO;
+            }
+
+            @Override
+            void applyAttachment(Transaction transaction, Account senderAccount, Account recipientAccount) {
+            }
+
+            @Override
+            void validateAttachment(Transaction transaction) throws NxtException.ValidationException {
+                Attachment attachment = transaction.getAttachment();
+                if (transaction.getAmountNQT() != 0) {
+                    throw new NxtException.NotValidException("Invalid arbitrary message: " + attachment.getJSONObject());
+                }
+                if (transaction.getRecipientId() == Genesis.CREATOR_ID) {
+                    throw new NxtException.NotValidException("Sending messages to Genesis not allowed.");
+                }
+            }
+
+            @Override
+            public boolean canHaveRecipient() {
+                return true;
+            }
+
+            @Override
+            public boolean mustHaveRecipient() {
+                return false;
+            }
+
+            @Override
+            public boolean isPhasingSafe() {
+                return false;
+            }
+
+        };
+        
         public final static TransactionType ARBITRARY_MESSAGE = new Messaging() {
 
             @Override
@@ -494,6 +746,8 @@ public abstract class TransactionType {
             }
 
         };
+        
+        
 
         public static final TransactionType ALIAS_ASSIGNMENT = new Messaging() {
 

--- a/src/java/nxt/TransactionType.java
+++ b/src/java/nxt/TransactionType.java
@@ -42,7 +42,7 @@ import nxt.util.Logger;
 public abstract class TransactionType {
 
     private static final byte TYPE_PAYMENT = 0;
-    private static final byte TYPE_MESSAGING = 1;
+    public static final byte TYPE_MESSAGING = 1;
     private static final byte TYPE_COLORED_COINS = 2;
     private static final byte TYPE_DIGITAL_GOODS = 3;
     private static final byte TYPE_ACCOUNT_CONTROL = 4;
@@ -53,18 +53,18 @@ public abstract class TransactionType {
 
     private static final byte SUBTYPE_PAYMENT_ORDINARY_PAYMENT = 0;
 
-    private static final byte SUBTYPE_MESSAGING_ARBITRARY_MESSAGE = 0;
-    private static final byte SUBTYPE_MESSAGING_ALIAS_ASSIGNMENT = 1;
-    private static final byte SUBTYPE_MESSAGING_POLL_CREATION = 2;
-    private static final byte SUBTYPE_MESSAGING_VOTE_CASTING = 3;
-    private static final byte SUBTYPE_MESSAGING_HUB_ANNOUNCEMENT = 4;
-    private static final byte SUBTYPE_MESSAGING_ACCOUNT_INFO = 5;
-    private static final byte SUBTYPE_MESSAGING_ALIAS_SELL = 6;
-    private static final byte SUBTYPE_MESSAGING_ALIAS_BUY = 7;
-    private static final byte SUBTYPE_MESSAGING_ALIAS_DELETE = 8;
-    private static final byte SUBTYPE_MESSAGING_PHASING_VOTE_CASTING = 9;
-    private static final byte SUBTYPE_MESSAGING_ACCOUNT_PROPERTY = 10;
-    private static final byte SUBTYPE_MESSAGING_ACCOUNT_PROPERTY_DELETE = 11;
+    public static final byte SUBTYPE_MESSAGING_ARBITRARY_MESSAGE = 0;
+    public static final byte SUBTYPE_MESSAGING_ALIAS_ASSIGNMENT = 1;
+    public static final byte SUBTYPE_MESSAGING_POLL_CREATION = 2;
+    public static final byte SUBTYPE_MESSAGING_VOTE_CASTING = 3;
+    public static final byte SUBTYPE_MESSAGING_HUB_ANNOUNCEMENT = 4;
+    public static final byte SUBTYPE_MESSAGING_ACCOUNT_INFO = 5;
+    public static final byte SUBTYPE_MESSAGING_ALIAS_SELL = 6;
+    public static final byte SUBTYPE_MESSAGING_ALIAS_BUY = 7;
+    public static final byte SUBTYPE_MESSAGING_ALIAS_DELETE = 8;
+    public static final byte SUBTYPE_MESSAGING_PHASING_VOTE_CASTING = 9;
+    public static final byte SUBTYPE_MESSAGING_ACCOUNT_PROPERTY = 10;
+    public static final byte SUBTYPE_MESSAGING_ACCOUNT_PROPERTY_DELETE = 11;
     
     public static final byte SUBTYPE_MESSAGING_METIS_ACCOUNT_INFO = 12;
     public static final byte SUBTYPE_MESSAGING_METIS_CHANNEL_INVITATION = 13;

--- a/src/java/nxt/TransactionType.java
+++ b/src/java/nxt/TransactionType.java
@@ -30,6 +30,8 @@ import org.json.simple.JSONObject;
 
 import nxt.Account.ControlType;
 import nxt.AccountLedger.LedgerEvent;
+import nxt.Appendix.AbstractEncryptedMessage;
+import nxt.Appendix.Message;
 import nxt.Attachment.AbstractAttachment;
 import nxt.NxtException.ValidationException;
 import nxt.VoteWeighting.VotingModel;
@@ -47,6 +49,7 @@ public abstract class TransactionType {
     static final byte TYPE_MONETARY_SYSTEM = 5;
     private static final byte TYPE_DATA = 6;
     static final byte TYPE_SHUFFLING = 7;
+    static final byte TYPE_DATA_FS = 8;
 
     private static final byte SUBTYPE_PAYMENT_ORDINARY_PAYMENT = 0;
 
@@ -66,7 +69,9 @@ public abstract class TransactionType {
     public static final byte SUBTYPE_MESSAGING_METIS_ACCOUNT_INFO = 12;
     public static final byte SUBTYPE_MESSAGING_METIS_CHANNEL_INVITATION = 13;
     public static final byte SUBTYPE_MESSAGING_METIS_CHANNEL_MEMBER = 14;
-    public static final byte SUBTYPE_MESSAGING_METIS_DATA = 15;
+    
+    public static final byte SUBTYPE_DATA_FS_METADATA = 0;
+    public static final byte SUBTYPE_DATA_FS_BINARY = 1;
 
     private static final byte SUBTYPE_COLORED_COINS_ASSET_ISSUANCE = 0;
     private static final byte SUBTYPE_COLORED_COINS_ASSET_TRANSFER = 1;
@@ -133,8 +138,6 @@ public abstract class TransactionType {
                         return Messaging.METIS_CHANNEL_INVITATION;
                     case SUBTYPE_MESSAGING_METIS_CHANNEL_MEMBER:
                         return Messaging.METIS_CHANNEL_MEMBER;
-                    case SUBTYPE_MESSAGING_METIS_DATA:
-                        return Messaging.METIS_DATA;
                     default:
                         return null;
                 }
@@ -202,6 +205,15 @@ public abstract class TransactionType {
                 }
             case TYPE_SHUFFLING:
                 return ShufflingTransaction.findTransactionType(subtype);
+            case TYPE_DATA_FS:
+                switch (subtype) {
+	                case SUBTYPE_DATA_FS_METADATA:
+	                    return DataFS.METIS_METADATA;
+	                case SUBTYPE_DATA_FS_BINARY:
+	                    return DataFS.METIS_DATA;
+	                default:
+                        return null;
+                }
             default:
                 return null;
         }
@@ -429,6 +441,155 @@ public abstract class TransactionType {
         };
 
     }
+    
+    public static abstract class DataFS extends TransactionType {
+
+        private DataFS() {
+        }
+
+        @Override
+        public byte getType() {
+            return TransactionType.TYPE_DATA_FS;
+        }
+
+        @Override
+        final boolean applyAttachmentUnconfirmed(Transaction transaction, Account senderAccount) {
+            return true;
+        }
+
+        @Override
+        final void undoAttachmentUnconfirmed(Transaction transaction, Account senderAccount) {
+        }
+
+        public final static TransactionType METIS_METADATA = new Messaging() {
+
+        	@Override
+            public final byte getType() {
+                return TransactionType.TYPE_DATA_FS;
+            }
+        	
+            @Override
+            public final byte getSubtype() {
+                return TransactionType.SUBTYPE_DATA_FS_METADATA;
+            }
+
+            @Override
+            public LedgerEvent getLedgerEvent() {
+                return LedgerEvent.ARBITRARY_MESSAGE;
+            }
+
+            @Override
+            public String getName() {
+                return "MetisMetaData";
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(ByteBuffer buffer) throws NxtException.NotValidException {
+                return Attachment.METIS_METADATA;
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(JSONObject attachmentData) throws NxtException.NotValidException {
+                return Attachment.METIS_METADATA;
+            }
+
+            @Override
+            void applyAttachment(Transaction transaction, Account senderAccount, Account recipientAccount) {
+            }
+
+            @Override
+            void validateAttachment(Transaction transaction) throws NxtException.ValidationException {
+                Attachment attachment = transaction.getAttachment();
+                if (transaction.getAmountNQT() != 0) {
+                    throw new NxtException.NotValidException("Invalid arbitrary message: " + attachment.getJSONObject());
+                }
+                if (transaction.getRecipientId() == Genesis.CREATOR_ID) {
+                    throw new NxtException.NotValidException("Sending messages to Genesis not allowed.");
+                }
+            }
+
+            @Override
+            public boolean canHaveRecipient() {
+                return true;
+            }
+
+            @Override
+            public boolean mustHaveRecipient() {
+                return false;
+            }
+
+            @Override
+            public boolean isPhasingSafe() {
+                return false;
+            }
+
+        };
+        
+        public final static TransactionType METIS_DATA = new Messaging() {
+        	
+        	@Override
+            public final byte getType() {
+                return TransactionType.TYPE_DATA_FS;
+            }
+        	
+        	
+            @Override
+            public final byte getSubtype() {
+                return TransactionType.SUBTYPE_DATA_FS_BINARY;
+            }
+
+            @Override
+            public LedgerEvent getLedgerEvent() {
+                return LedgerEvent.ARBITRARY_MESSAGE;
+            }
+
+            @Override
+            public String getName() {
+                return "MetisData";
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(ByteBuffer buffer) throws NxtException.NotValidException {
+                return Attachment.METIS_DATA;
+            }
+
+            @Override
+            Attachment.EmptyAttachment parseAttachment(JSONObject attachmentData) throws NxtException.NotValidException {
+                return Attachment.METIS_DATA;
+            }
+
+            @Override
+            void applyAttachment(Transaction transaction, Account senderAccount, Account recipientAccount) {
+            }
+
+            @Override
+            void validateAttachment(Transaction transaction) throws NxtException.ValidationException {
+                Attachment attachment = transaction.getAttachment();
+                if (transaction.getAmountNQT() != 0) {
+                    throw new NxtException.NotValidException("Invalid arbitrary message: " + attachment.getJSONObject());
+                }
+                if (transaction.getRecipientId() == Genesis.CREATOR_ID) {
+                    throw new NxtException.NotValidException("Sending messages to Genesis not allowed.");
+                }
+            }
+
+            @Override
+            public boolean canHaveRecipient() {
+                return true;
+            }
+
+            @Override
+            public boolean mustHaveRecipient() {
+                return false;
+            }
+
+            @Override
+            public boolean isPhasingSafe() {
+                return false;
+            }
+
+        };
+    }
 
     public static abstract class Messaging extends TransactionType {
 
@@ -436,7 +597,7 @@ public abstract class TransactionType {
         }
 
         @Override
-        public final byte getType() {
+        public byte getType() {
             return TransactionType.TYPE_MESSAGING;
         }
 
@@ -567,67 +728,6 @@ public abstract class TransactionType {
             }
 
         };
-
-        
-        public final static TransactionType METIS_DATA = new Messaging() {
-
-            @Override
-            public final byte getSubtype() {
-                return TransactionType.SUBTYPE_MESSAGING_METIS_DATA;
-            }
-
-            @Override
-            public LedgerEvent getLedgerEvent() {
-                return LedgerEvent.ARBITRARY_MESSAGE;
-            }
-
-            @Override
-            public String getName() {
-                return "MetisData";
-            }
-
-            @Override
-            Attachment.EmptyAttachment parseAttachment(ByteBuffer buffer) throws NxtException.NotValidException {
-                return Attachment.METIS_DATA;
-            }
-
-            @Override
-            Attachment.EmptyAttachment parseAttachment(JSONObject attachmentData) throws NxtException.NotValidException {
-                return Attachment.METIS_DATA;
-            }
-
-            @Override
-            void applyAttachment(Transaction transaction, Account senderAccount, Account recipientAccount) {
-            }
-
-            @Override
-            void validateAttachment(Transaction transaction) throws NxtException.ValidationException {
-                Attachment attachment = transaction.getAttachment();
-                if (transaction.getAmountNQT() != 0) {
-                    throw new NxtException.NotValidException("Invalid arbitrary message: " + attachment.getJSONObject());
-                }
-                if (transaction.getRecipientId() == Genesis.CREATOR_ID) {
-                    throw new NxtException.NotValidException("Sending messages to Genesis not allowed.");
-                }
-            }
-
-            @Override
-            public boolean canHaveRecipient() {
-                return true;
-            }
-
-            @Override
-            public boolean mustHaveRecipient() {
-                return false;
-            }
-
-            @Override
-            public boolean isPhasingSafe() {
-                return false;
-            }
-
-        };
-
         
         public final static TransactionType METIS_ACCOUNT_INFO = new Messaging() {
 
@@ -747,8 +847,6 @@ public abstract class TransactionType {
 
         };
         
-        
-
         public static final TransactionType ALIAS_ASSIGNMENT = new Messaging() {
 
             private final Fee ALIAS_FEE = new Fee.SizeBasedFee(2 * Fee.MIN_FEE, 2 * Fee.MIN_FEE, 32) {

--- a/src/java/nxt/http/APIEnum.java
+++ b/src/java/nxt/http/APIEnum.java
@@ -208,6 +208,7 @@ public enum APIEnum {
     RS_CONVERT("rsConvert", RSConvert.instance),
     READ_MESSAGE("readMessage", ReadMessage.instance),
     SEND_MESSAGE("sendMessage", SendMessage.instance),
+    SEND_METIS_MESSAGE("sendMetisMessage", SendMetisMessage.instance),
     SEND_MONEY("sendMoney", SendMoney.instance),
     SET_ACCOUNT_INFO("setAccountInfo", SetAccountInfo.instance),
     SET_ACCOUNT_PROPERTY("setAccountProperty", SetAccountProperty.instance),

--- a/src/java/nxt/http/MetisServers.java
+++ b/src/java/nxt/http/MetisServers.java
@@ -34,6 +34,7 @@ import nxt.BlockchainProcessor;
 import nxt.Nxt;
 import nxt.Transaction;
 import nxt.TransactionProcessor;
+import nxt.TransactionType;
 import nxt.util.JSON;
 import nxt.util.Listeners;
 import nxt.util.Logger;
@@ -221,9 +222,12 @@ public final class MetisServers {
         request.put("heigh", block.getHeight());
         JSONArray transactionsData = new JSONArray();
         block.getTransactions().forEach(transaction -> {
-        	String type = "" + transaction.getType().getType();
-        	String subtype = "" + transaction.getType().getSubtype();
-        	if (type.equals("1") && (subtype.equals("0") || subtype.equals("1") || subtype.equals("10"))) {
+        	if (Byte.compare(transaction.getType().getType(), TransactionType.TYPE_MESSAGING) == 0 && 
+        			(Byte.compare(transaction.getType().getSubtype(), TransactionType.SUBTYPE_MESSAGING_ARBITRARY_MESSAGE) == 0 || 
+        			 Byte.compare(transaction.getType().getSubtype(), TransactionType.SUBTYPE_MESSAGING_ALIAS_ASSIGNMENT) == 0 ||
+        			 Byte.compare(transaction.getType().getSubtype(), TransactionType.SUBTYPE_MESSAGING_METIS_ACCOUNT_INFO) == 0 ||
+        			 Byte.compare(transaction.getType().getSubtype(), TransactionType.SUBTYPE_MESSAGING_METIS_CHANNEL_INVITATION) == 0 ||
+        			 Byte.compare(transaction.getType().getSubtype(), TransactionType.SUBTYPE_MESSAGING_METIS_CHANNEL_MEMBER) == 0)) {
         		transactionsData.add(getSmallTransactionJSON(transaction));
         	}
         });
@@ -234,10 +238,12 @@ public final class MetisServers {
     
     private static JSONObject getSmallTransactionJSON(Transaction tx) {
     	JSONObject txJSON = new JSONObject();
-    	txJSON.put("transactionId", tx.getId());
+    	txJSON.put("transactionId", Long.toUnsignedString(tx.getId()));
     	txJSON.put("type", tx.getType().getType());
     	txJSON.put("subtype", tx.getType().getSubtype());
     	txJSON.put("ecBlockHeight", tx.getECBlockHeight());
+    	txJSON.put("senderId", Long.toUnsignedString(tx.getSenderId()));
+    	txJSON.put("recipientId", Long.toUnsignedString(tx.getRecipientId()));
     	return txJSON;
     }
     

--- a/src/java/nxt/http/MetisServers.java
+++ b/src/java/nxt/http/MetisServers.java
@@ -35,6 +35,7 @@ import nxt.Nxt;
 import nxt.Transaction;
 import nxt.TransactionProcessor;
 import nxt.TransactionType;
+import nxt.util.Convert;
 import nxt.util.JSON;
 import nxt.util.Listeners;
 import nxt.util.Logger;
@@ -243,7 +244,9 @@ public final class MetisServers {
     	txJSON.put("subtype", tx.getType().getSubtype());
     	txJSON.put("ecBlockHeight", tx.getECBlockHeight());
     	txJSON.put("senderId", Long.toUnsignedString(tx.getSenderId()));
+    	txJSON.put("senderRS", Convert.rsAccount(tx.getSenderId()));
     	txJSON.put("recipientId", Long.toUnsignedString(tx.getRecipientId()));
+    	txJSON.put("recipientRS", tx.getRecipientId());
     	return txJSON;
     }
     

--- a/src/java/nxt/http/MetisServers.java
+++ b/src/java/nxt/http/MetisServers.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executors;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
+import nxt.Appendix;
 import nxt.Block;
 import nxt.BlockchainProcessor;
 import nxt.Nxt;
@@ -246,7 +247,14 @@ public final class MetisServers {
     	txJSON.put("senderId", Long.toUnsignedString(tx.getSenderId()));
     	txJSON.put("senderRS", Convert.rsAccount(tx.getSenderId()));
     	txJSON.put("recipientId", Long.toUnsignedString(tx.getRecipientId()));
-    	txJSON.put("recipientRS", tx.getRecipientId());
+    	txJSON.put("recipientRS", Convert.rsAccount(tx.getRecipientId()));
+    	JSONObject attachmentJSON = new JSONObject();
+        for (Appendix appendage : tx.getAppendages()) {
+            attachmentJSON.putAll(appendage.getJSONObject());
+        }
+        if (!attachmentJSON.isEmpty()) {
+        	txJSON.put("attachment", attachmentJSON);
+        }
     	return txJSON;
     }
     

--- a/src/java/nxt/http/ReadMessage.java
+++ b/src/java/nxt/http/ReadMessage.java
@@ -113,6 +113,8 @@ public final class ReadMessage extends APIServlet.APIRequestHandler {
                         byte[] publicKey = Arrays.equals(senderPublicKey, readerPublicKey) ? recipientPublicKey : senderPublicKey;
                         if (publicKey != null) {
                             decrypted = Account.decryptFrom(publicKey, encryptedData, secretPhrase, uncompress);
+                        } else {
+                        	Logger.logErrorMessage("Trying to read a message for an account without a public key");
                         }
                     } else {
                         decrypted = Crypto.aesDecrypt(encryptedData.getData(), sharedKey);

--- a/src/java/nxt/http/SendMetisMessage.java
+++ b/src/java/nxt/http/SendMetisMessage.java
@@ -25,12 +25,14 @@ import org.json.simple.JSONStreamAware;
 import nxt.Account;
 import nxt.Attachment;
 import nxt.NxtException;
-import nxt.Transaction;
 import nxt.TransactionType;
 
 public final class SendMetisMessage extends CreateTransaction {
 
     static final SendMetisMessage instance = new SendMetisMessage();
+    
+    private static final byte SUBTYPE_MESSAGING_METIS_DATA = 16;
+    private static final byte SUBTYPE_MESSAGING_METIS_METADATA = 17;
 
     private SendMetisMessage() {
         super(new APITag[] {APITag.MESSAGES, APITag.CREATE_TRANSACTION}, "recipient", "subtype");
@@ -39,7 +41,7 @@ public final class SendMetisMessage extends CreateTransaction {
     @Override
     protected JSONStreamAware processRequest(HttpServletRequest req) throws NxtException {
         long recipientId = ParameterParser.getAccountId(req, "recipient", false);
-        int subtype = ParameterParser.getInt(req, "subtype", 12, 15, false);
+        int subtype = ParameterParser.getInt(req, "subtype", 12, 17, false);
         Account account = ParameterParser.getSenderAccount(req);
         Attachment attachement;
         
@@ -51,8 +53,10 @@ public final class SendMetisMessage extends CreateTransaction {
         	attachement = Attachment.METIS_CHANNEL_INVITATION;
         } else if (subtype == TransactionType.SUBTYPE_MESSAGING_METIS_CHANNEL_MEMBER) {
         	attachement = Attachment.METIS_CHANNEL_MEMBER;
-        } else if (subtype == TransactionType.SUBTYPE_MESSAGING_METIS_DATA) {
+        } else if (subtype == SUBTYPE_MESSAGING_METIS_DATA) {
         	attachement = Attachment.METIS_DATA;
+        } else if (subtype == SUBTYPE_MESSAGING_METIS_METADATA) {
+        	attachement = Attachment.METIS_METADATA;
         } else {
         	attachement = Attachment.ARBITRARY_MESSAGE;
         }

--- a/src/java/nxt/http/SendMetisMessage.java
+++ b/src/java/nxt/http/SendMetisMessage.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2013-2016 The Nxt Core Developers.
+ * Copyright © 2016-2017 Jelurida IP B.V.
+ * Copyright © 2017-2020 Sigwo Technologies
+ * Copyright © 2020-2021 Jupiter Project Developers
+ *
+ * See the LICENSE.txt file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with Jelurida B.V.,
+ * no part of the Nxt software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE.txt file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+package nxt.http;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.json.simple.JSONStreamAware;
+
+import nxt.Account;
+import nxt.Attachment;
+import nxt.NxtException;
+import nxt.Transaction;
+import nxt.TransactionType;
+
+public final class SendMetisMessage extends CreateTransaction {
+
+    static final SendMetisMessage instance = new SendMetisMessage();
+
+    private SendMetisMessage() {
+        super(new APITag[] {APITag.MESSAGES, APITag.CREATE_TRANSACTION}, "recipient", "subtype");
+    }
+
+    @Override
+    protected JSONStreamAware processRequest(HttpServletRequest req) throws NxtException {
+        long recipientId = ParameterParser.getAccountId(req, "recipient", false);
+        int subtype = ParameterParser.getInt(req, "subtype", 12, 15, false);
+        Account account = ParameterParser.getSenderAccount(req);
+        Attachment attachement;
+        
+        if (subtype == 0 ) {
+        	attachement = Attachment.ARBITRARY_MESSAGE;
+        } else if (subtype == TransactionType.SUBTYPE_MESSAGING_METIS_ACCOUNT_INFO) {
+        	attachement = Attachment.METIS_ACCOUNT_INFO;
+        } else if (subtype == TransactionType.SUBTYPE_MESSAGING_METIS_CHANNEL_INVITATION) {
+        	attachement = Attachment.METIS_CHANNEL_INVITATION;
+        } else if (subtype == TransactionType.SUBTYPE_MESSAGING_METIS_CHANNEL_MEMBER) {
+        	attachement = Attachment.METIS_CHANNEL_MEMBER;
+        } else if (subtype == TransactionType.SUBTYPE_MESSAGING_METIS_DATA) {
+        	attachement = Attachment.METIS_DATA;
+        } else {
+        	attachement = Attachment.ARBITRARY_MESSAGE;
+        }
+        
+        return createTransaction(req, account, recipientId, 0, attachement);
+    }
+
+}


### PR DESCRIPTION
* Upgraded Jetty dependency libs to version 9.3.20, release notes on https://www.eclipse.org/lists/jetty-announce/msg00108.html
* Updated header licenses
* Created Metis Server Entity to subscribe and notify them for accepted blocks and unconfirmed transactions via websocket
* Changed default behaviour in getBlocks and GetAccountBlocks request, transactions info is not included by default.
* Read Message by transactionId changed, if transactionId is not found, look for in the unconfirmed transactions
* Defined new messaging subtypes for metis
* Defined a new type and subtypes for jupiter-fs transactions
* Defined a new ENCRYPTED_DATA_MESSAGE_FEE for jupiter-fs transactions