### PR TITLE
Update base target warning

### DIFF
--- a/html/www/js/nrs.js
+++ b/html/www/js/nrs.js
@@ -1701,7 +1701,7 @@ NRS.addPagination = function () {
 				});
 			}
 
-            if (NRS.blocks && NRS.blocks.length > 0 && NRS.baseTargetPercent(NRS.blocks[0]) > 1000 && !NRS.isTestNet) {
+            if (NRS.blocks && NRS.blocks.length > 0 && NRS.baseTargetPercent(NRS.blocks[0]) > 25000 && !NRS.isTestNet) {
                 $.growl($.t("fork_warning_base_target"), {
                     "type": "danger"
                 });


### PR DESCRIPTION
Base target % are larger now that we burned excess JUP. Warning popup needed a larger % to check for forking.