### PR TITLE
Update nxt-default.properties

### DIFF
--- a/conf/nxt-default.properties
+++ b/conf/nxt-default.properties
@@ -71,10 +71,7 @@ nxt.defaultPeers=
 
 # A list of well known peer addresses / host names, separated by '; '. These
 # peers are always kept in connected state.
-nxt.wellKnownPeers=185.170.214.100;45.55.206.157;75.119.145.94;85.10.202.143;
-46.101.246.70;20.52.219.222;52.156.75.109;161.97.168.245;13.82.236.249;40.127.98.116;
-128.199.38.216;52.168.170.194;13.92.58.230;192.81.216.82;84.252.122.208;20.199.113.20;
-20.97.220.93;172.104.243.232;45.63.10.173;stats.jup.io;
+nxt.wellKnownPeers=192.81.216.82;stats.jup.io;node-eu-de.jupitertoolkit.com;node-eu-nl.jupitertoolkit.com;84.132.93.180;62.171.167.69;58.174.66.1;80.241.219.227;18.116.89.46;
 
 # Known bad peers to be blacklisted.
 nxt.knownBlacklistedPeers=jill.airdns.org:17874;50.225.198.67:6221;


### PR DESCRIPTION
Most peers in the current wellKnownPeers list aren't online anymore.