### PR TITLE
Update blocktime to 12 seconds in front-end

### DIFF
--- a/html/www/js/nrs.blocks.js
+++ b/html/www/js/nrs.blocks.js
@@ -21,7 +21,7 @@ var NRS = (function(NRS, $) {
 	NRS.blocksPageType = null;
 	NRS.tempBlocks = [];
 	var trackBlockchain = false;
-	NRS.averageBlockGenerationTime = 60;
+	NRS.averageBlockGenerationTime = 12;
 
 	NRS.getBlock = function(id, callback, pageRequest) {
 		NRS.sendRequest("getBlock" + (pageRequest ? "+" : ""), {


### PR DESCRIPTION
This is used, among other things, for calculating estimated block arrival.