### PR TITLE
Revert additional memory allocation in start.sh and run.bat

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -57,7 +57,7 @@
 	)
 
 :startJava	
-	start "Jupiter JRS from %~dp0" "%javaDir%"\bin\java.exe -Xms2048m -Xmx4096m -cp classes;lib\*;conf;addons\classes;addons\lib\* -Dnxt.runtime.mode=desktop nxt.Nxt
+	start "Jupiter JRS from %~dp0" "%javaDir%"\bin\java.exe -cp classes;lib\*;conf;addons\classes;addons\lib\* -Dnxt.runtime.mode=desktop nxt.Nxt
 
 :endProcess 
 	endlocal

--- a/start.sh
+++ b/start.sh
@@ -17,6 +17,6 @@ if [ -x jre/bin/java ]; then
 else
     JAVA=java
 fi
-nohup ${JAVA} -Xms2048m -Xmx4096m -cp classes:lib/*:conf:addons/classes:addons/lib/* -Dnxt.runtime.mode=desktop nxt.Nxt > /dev/null 2>&1 &
+nohup ${JAVA} -cp classes:lib/*:conf:addons/classes:addons/lib/* -Dnxt.runtime.mode=desktop nxt.Nxt > /dev/null 2>&1 &
 echo $! > ~/.${APPLICATION}/nxt.pid
 cd - > /dev/null


### PR DESCRIPTION
Revert additional memory allocation, as it's causing node crashes and is not needed for normal usage. 